### PR TITLE
feat: open new window from Favorites/Recent menus (match taskButton behavior)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -241,7 +241,12 @@ class FavoritesMenuButton extends PanelMenu.Button {
             const item = new PopupMenu.PopupImageMenuItem(favorite?.get_name(), favorite?.icon);
             this.menu?.addMenuItem(item);
 
-            item.connect('activate', () => favorite?.activate());
+            item.connect('activate', () => {
+                if (favorite?.can_open_new_window())
+                    favorite?.open_new_window(-1);
+                else
+                    favorite?.activate();
+            });
         }
     }
 
@@ -287,7 +292,12 @@ class RecentAppsMenuButton extends PanelMenu.Button {
             const item = new PopupMenu.PopupImageMenuItem(app?.get_name(), app?.icon);
             this.menu?.addMenuItem(item);
 
-            item.connect('activate', () => app?.activate());
+            item.connect('activate', () => {
+                if (app?.can_open_new_window())
+                    app?.open_new_window(-1);
+                else
+                    app?.activate();
+            });
         }
     }
 


### PR DESCRIPTION
## Summary

The **Favorites** and **Recent Apps** menus launch apps with `app.activate()`. When the app
is already running, `activate()` raises its existing window (on whatever monitor it lives on)
instead of opening a new one. From a launcher-style menu, clicking an entry is expected to
*open* the app.

This changes both menus to use the same primitive the extension's own `taskButton` already
uses for middle-click ("new window"):

```js
if (app?.can_open_new_window())
    app?.open_new_window(-1);
else
    app?.activate();   // single-instance fallback
```

So the behavior is now consistent across the extension, and on multi-monitor setups the new
window opens on the monitor where the menu was invoked (pointer location).

## Why

- **Consistency**: `taskButton` already exposes new-window launching via `can_open_new_window()` /
  `open_new_window(-1)`; the Favorites/Recent menus should behave the same when used as launchers.
- **Multi-monitor**: on a per-monitor panel layout, `activate()` pulls focus to another screen's
  existing window; `open_new_window(-1)` keeps the launch on the current screen.
- **Safe fallback**: single-instance apps that can't open a new window fall back to `activate()`,
  so nothing regresses.

## Changes

- `extension.js` — `FavoritesMenuButton._updateFavorites()` and
  `RecentAppsMenuButton._updateRecentApps()`: `activate()` → `can_open_new_window()` guard +
  `open_new_window(-1)` with `activate()` fallback. (+12 / -2)

## Testing

GNOME Shell 50.1 / Wayland / Fedora 44, multi-monitor (DisplayLink). Favorites and Recent menu
entries now open a new window on the active monitor; single-instance apps still just activate.
`node --check` passes.
